### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Cano
 maintainer=Cano
 sentence=Simplify your code by hooking up onClick events to your buttons
 paragraph=Supports buttons connected to digital pins, multiple buttons to analog pins, various port extenders like MCP23S08
-category=Input
+category=Signal Input/Output
 url=https://github.com/cano64/ArduinoButtons
 architectures=avr


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Input' in library ArduinoButtons is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format